### PR TITLE
Use scratch in docker_sample project

### DIFF
--- a/docker_sample/Dockerfile
+++ b/docker_sample/Dockerfile
@@ -1,15 +1,10 @@
 FROM rust:1 as builder
+WORKDIR /app
+ADD . /app
+RUN rustup target add x86_64-unknown-linux-musl
+RUN USER=root CARGO_HTTP_MULTIPLEXING=false cargo build --release --target x86_64-unknown-linux-musl
 
-COPY . .
-
-RUN cargo build --release
-
-FROM rust:1-slim-stretch
-
-COPY --from=builder /target/release/docker_sample .
-
-RUN ls -la /docker_sample
-
+FROM scratch
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/hello-world /app
 EXPOSE 5000
-
-ENTRYPOINT ["/docker_sample"]
+CMD ["/app"]

--- a/docker_sample/Dockerfile
+++ b/docker_sample/Dockerfile
@@ -2,9 +2,9 @@ FROM rust:1 as builder
 WORKDIR /app
 ADD . /app
 RUN rustup target add x86_64-unknown-linux-musl
-RUN USER=root CARGO_HTTP_MULTIPLEXING=false cargo build --release --target x86_64-unknown-linux-musl
+RUN CARGO_HTTP_MULTIPLEXING=false cargo build --release --target x86_64-unknown-linux-musl
 
 FROM scratch
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/hello-world /app
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/docker_sample /app
 EXPOSE 5000
 CMD ["/app"]

--- a/docker_sample/src/main.rs
+++ b/docker_sample/src/main.rs
@@ -14,7 +14,7 @@ async fn again() -> HttpResponse {
 
 #[ntex::main]
 async fn main() -> std::io::Result<()> {
-    println!("Starting actix-web server");
+    println!("Starting ntex-web server");
 
     web::server(|| App::new().service((index, again)))
         .bind("0.0.0.0:5000")?


### PR DESCRIPTION
Using scratch will make the image smallest possible size to 8Mb.